### PR TITLE
Adds shared scripts and script to generate schema for js unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dbdata
+/shop

--- a/scripts/generate-shared-schema.sh
+++ b/scripts/generate-shared-schema.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+# Generates shared schema from server .graphql for use in any graphql related unit tests
+PARENT_DIR="$(dirname `pwd`)"
+SCHEMA_DIR=$PARENT_DIR/server/src/GraphQL/schema
+OUTPUT_DIR=$PARENT_DIR/shared/js/schema
+for f in $SCHEMA_DIR/*.graphql; do
+	CONTENTS=$(cat $f)
+	CONTENTS=${CONTENTS//\\\\/\\}
+	CONTENTS=${CONTENTS//\`/}
+  	echo "export default \` $CONTENTS \` " > "$OUTPUT_DIR/${f##*/}.js"
+done

--- a/shared/js/schema/common.schema.js
+++ b/shared/js/schema/common.schema.js
@@ -1,0 +1,42 @@
+// Sets definitions so our graphql is not invalid
+const directives = `
+  directive @paginate(
+      type: String,
+      model: String,
+      scopes: String,
+      builder: String
+  ) on FIELD_DEFINITION
+  directive @can(
+      type: Boolean,
+      ability: String
+      model: String
+      policy: String
+      find: String
+  ) on FIELD_DEFINITION
+  directive @find(
+      model: String
+  ) on FIELD_DEFINITION
+  directive @field(
+      resolver: String
+  ) on FIELD_DEFINITION
+  directive @gate(
+      ability: String
+      sessionOnly: Boolean
+  ) on FIELD_DEFINITION
+  directive @hasOne on FIELD_DEFINITION
+  directive @belongsTo on FIELD_DEFINITION
+  directive @spread on ARGUMENT_DEFINITION
+  directive @eq on ARGUMENT_DEFINITION
+  directive @rules(
+      apply: String
+  ) on INPUT_FIELD_DEFINITION
+  directive @gernzyConvertCurrency on FIELD_DEFINITION
+  directive @hasMany(
+    type: String
+  ) on FIELD_DEFINITION
+  directive @all(
+    model: String
+  ) on FIELD_DEFINITION
+`;
+
+export default directives;

--- a/shared/js/schema/orders.graphql.js
+++ b/shared/js/schema/orders.graphql.js
@@ -1,0 +1,82 @@
+export default ` extend type Mutation {
+    checkout(input: CheckoutInput!): CheckoutPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Checkout@checkout")
+        @gate(ability: "can-checkout", sessionOnly: true)
+}
+
+extend type Query {
+    order(id: ID @eq): Order
+        @find(model: "Lab19\Cart\Models\Order")
+        @can(
+            ability: "view"
+            find: "id"
+            model: "Lab19\Cart\Models\Order"
+            policy: "Lab19\Cart\Policies\OrderPolicy"
+        )
+}
+
+input CheckoutInput {
+    name: String! @rules(apply: ["required"])
+    email: String! @rules(apply: ["required", "email"])
+    mobile: String!
+    telephone: String!
+    billing_address: BillingAddress! @rules(apply: ["required"])
+    shipping_address: ShippingAddress! @rules(apply: ["required"])
+    use_shipping_for_billing: Boolean!
+    payment_method: String!
+    agree_to_terms: Boolean!
+    notes: String!
+}
+
+input BillingAddress {
+    line_1: String! @rules(apply: ["required"])
+    line_2: String
+    state: String! @rules(apply: ["required"])
+    postcode: String
+    country: String!
+}
+
+input ShippingAddress {
+    line_1: String! @rules(apply: ["required"])
+    line_2: String
+    state: String! @rules(apply: ["required"])
+    postcode: String
+    country: String! @rules(apply: ["required"])
+}
+
+type CheckoutPayload {
+    success: Boolean!
+    order: Order
+}
+
+extend type Mutation {
+    createOrder(input: CheckoutInput!): Order
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Order@create")
+        @can(ability: "create", model: "Lab19\Cart\Models\Order", policy: "Lab19\Cart\Policies\OrderPolicy")
+    updateOrder(id: ID!, input: UpdateOrderInput!): Order
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Order@update")
+        @can(ability: "update", model: "Lab19\Cart\Models\Order", policy: "Lab19\Cart\Policies\OrderPolicy")
+    setOrderItems(id: ID!, input: [SetOrderItemsInput!]): Order
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Order@setItems")
+        @can(ability: "update", model: "Lab19\Cart\Models\Order", policy: "Lab19\Cart\Policies\OrderPolicy")
+    deleteOrder(id: ID!): DeleteResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Order@delete")
+        @can(ability: "delete", model: "Lab19\Cart\Models\Order", policy: "Lab19\Cart\Policies\OrderPolicy")
+}
+
+input UpdateOrderInput {
+    name: String
+    email: String @rules(apply: ["email"])
+    mobile: String
+    telephone: String
+    billing_address: BillingAddress
+    shipping_address: ShippingAddress
+    use_shipping_for_billing: Boolean
+    payment_method: String
+    notes: String
+}
+
+input SetOrderItemsInput {
+    product_id: ID!
+    quantity: Int!
+} ` 

--- a/shared/js/schema/products.graphql.js
+++ b/shared/js/schema/products.graphql.js
@@ -1,0 +1,232 @@
+export default ` extend type Query {
+    products(input: ProductsQueryInput): [Product!]!
+        @gernzyConvertCurrency
+        @paginate(
+            type: "paginator"
+            model: "Lab19\Cart\Models\Product"
+            scopes: ["published", "inStock"]
+            builder: "Lab19\Cart\GraphQL\Builders\ProductsBuilder@search"
+        )
+
+    product(id: ID @eq): Product @find(model: "Lab19\Cart\Models\Product")
+
+    productsByCategories(input: ProductsCategoriesInput): [Product!]!
+        @paginate(
+            type: "paginator"
+            model: "Lab19\Cart\Models\Product"
+            scopes: ["published", "inStock"]
+            builder: "Lab19\Cart\GraphQL\Builders\ProductsBuilder@byCategory"
+        )
+
+    productsByTag(tag: Int!): [Product!]!
+        @paginate(type: "paginator", builder: "Lab19\Cart\GraphQL\Builders\ProductsBuilder@productsbytag")
+
+    productsByTags(tags: [Int!]): [Product!]!
+        @paginate(type: "paginator", builder: "Lab19\Cart\GraphQL\Builders\ProductsBuilder@productsByTags")
+}
+
+input ProductsQueryInput {
+    keyword: String
+    attributes: [ProductsQueryInputAttributes!]
+}
+
+input ProductsQueryInputAttributes {
+    name: String
+    value: String
+}
+
+input ProductsCategoriesInput {
+    ids: [Int!]
+    titles: [String!]
+}
+
+type Product {
+    id: ID!
+    parent_id: ID
+    title: String!
+    status: String!
+    published: Int!
+    price_cents: Int
+    price_currency: String
+    short_description: String
+    long_description: String
+    created_at: DateTime!
+    updated_at: DateTime!
+    meta: [ProductAttribute!]
+    prices: [ProductPrice!]
+    sizes: [ProductSize!]
+    variants: [Product!]
+    categories: [ProductCategory!]
+    dimensions: ProductDimensions
+    weight: ProductWeight
+    images: [Image!]
+    featured_image: Image
+    tags: [Tag!] @hasMany
+    fixedPrices: [ProductFixedPrice!] @hasMany
+}
+
+type ProductFixedPrice {
+    id: ID!
+    country_code: String
+    price: Float
+}
+
+type ProductDimensions {
+    length: Float
+    width: Float
+    height: Float
+    unit: String
+}
+
+type ProductWeight {
+    weight: Float
+    unit: String
+}
+
+type ProductCategory {
+    id: Int!
+    title: String!
+}
+
+extend type Mutation {
+    createProduct(input: CreateProductInput!): Product
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@create")
+        @can(ability: "create", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    updateProduct(id: ID!, input: UpdateProductInput!): Product
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@update")
+        @can(ability: "update", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    deleteProduct(id: ID!): DeleteResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@delete")
+        @can(ability: "delete", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+}
+
+input CreateProductInput {
+    title: String!
+    price_cents: Int
+    price_currency: String
+    short_description: String
+    long_description: String
+    meta: [ProductAttributeInput!]
+    prices: [ProductPriceInput!]
+    sizes: [ProductSizeInput!]
+    categories: [CategoryInput!]
+    dimensions: ProductDimensionsInput
+    weight: ProductWeightInput
+    fixprices: [PricingInput]
+}
+
+input PricingInput {
+    currency: String!
+    price_cents: Float
+}
+
+input ProductDimensionsInput {
+    length: Float
+    width: Float
+    height: Float
+    unit: String
+}
+
+input ProductWeightInput {
+    weight: Float
+    unit: String
+}
+
+input CategoryInput {
+    title: String
+    id: ID
+}
+
+input UpdateProductInput {
+    title: String
+    price_cents: Int
+    price_currency: String
+    short_description: String
+    long_description: String
+    meta: [ProductAttributeInput!]
+    prices: [ProductPriceInput!]
+    sizes: [ProductSizeInput!]
+    categories: [CategoryInput!]
+    dimensions: ProductDimensionsInput
+    weight: ProductWeightInput
+}
+
+input ProductAttributeInput {
+    key: String!
+    value: String!
+}
+
+input ProductPriceInput {
+    currency: String!
+    value: Int!
+}
+
+input ProductSizeInput {
+    size: String!
+}
+
+type DeleteResult {
+    success: Boolean!
+}
+
+type ProductAttribute {
+    id: ID!
+    group: String!
+    key: String!
+    value: String!
+    created_at: DateTime
+    updated_at: DateTime
+}
+
+type ProductPrice {
+    currency: String!
+    value: Int!
+}
+
+type ProductSize {
+    size: String!
+}
+
+extend type Mutation {
+    createProductVariant(id: ID!, input: CreateProductInput!): Product
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@createVariant")
+        @can(ability: "create", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    addImage(input: AddProductImage!): Image
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Image@create")
+        @can(ability: "create", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    addProductImages(product_id: ID!, images: [ID!]): AddProductImagesPayload!
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@attachImages")
+        @can(ability: "create", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    setProductFeaturedImage(product_id: ID!, image_id: ID!): SetProductFeaturedImagePayload!
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@setFeaturedImage")
+        @can(ability: "create", model: "Lab19\Cart\Models\Product", policy: "Lab19\Cart\Policies\ProductPolicy")
+    addProductTags(product_id: ID!, tags: [ID!]): AddProductTagsPayload!
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Product@attachTags")
+        @can(ability: "create", model: "Lab19\Cart\Models\Tag", policy: "Lab19\Cart\Policies\TagPolicy")
+}
+
+input AddProductImage {
+    file: Upload!
+    gallery: ID
+}
+
+type Image {
+    id: ID!
+    url: String!
+    type: String!
+    name: String!
+}
+
+type AddProductImagesPayload {
+    product: Product!
+    images: [Image!]
+}
+
+type AddProductTagsPayload {
+    product: Product!
+    tags: [Tag!]
+}
+
+type SetProductFeaturedImagePayload {
+    product: Product!
+} ` 

--- a/shared/js/schema/schema.graphql.js
+++ b/shared/js/schema/schema.graphql.js
@@ -1,0 +1,115 @@
+export default ` "A datetime string with format Y-m-d H:i:s, e.g. 2018-01-01 13:00:00."
+scalar DateTime @scalar(class: "Nuwave\Lighthouse\Schema\Types\Scalars\DateTime")
+
+"A date string with format Y-m-d, e.g. 2011-05-23."
+scalar Date @scalar(class: "Nuwave\Lighthouse\Schema\Types\Scalars\Date")
+
+"Can be used as an argument to upload files using https://github.com/jaydenseric/graphql-multipart-request-spec"
+scalar Upload @scalar(class: "Nuwave\Lighthouse\Schema\Types\Scalars\Upload")
+
+type Query {
+    users: [User!]!
+        @paginate(type: "paginator", model: "Lab19\Cart\Models\User")
+        @can(ability: "view", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    user(id: ID @eq): User
+        @find(model: "Lab19\Cart\Models\User")
+        @can(
+            ability: "view"
+            find: "id"
+            model: "Lab19\Cart\Models\User"
+            policy: "Lab19\Cart\Policies\UserPolicy"
+        )
+
+    orders: [Order!]! @paginate(type: "paginator", model: "Lab19\Cart\Models\Order")
+
+    order_items: [OrderItem!]! @paginate(type: "paginator", model: "Lab19\Cart\Models\OrderItem")
+    order_item(id: ID @eq): OrderItem @find(model: "Lab19\Cart\Models\OrderItem")
+
+    shopConfig: [String] @field(resolver: "Lab19\Cart\GraphQL\Queries\ShopConfig@enabledCurrencies")
+}
+
+type User {
+    id: ID!
+    name: String!
+    email: String!
+    cart: Cart
+    session: Session
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+type Order {
+    id: ID!
+    email: String!
+    name: String!
+    currency_id: Int!
+    cart_id: ID!
+    is_admin_order: Boolean!
+    cart: Cart @hasOne
+}
+
+type Cart {
+    id: ID!
+    order_id: ID
+    item_count: Int!
+    order: Cart @belongsTo
+    items: [CartItem!]
+    products: Int
+}
+
+type CartItem {
+    product_id: ID!
+    quantity: Int!
+}
+
+type OrderItem {
+    id: ID!
+    order_id: ID!
+}
+
+type Mutation {
+    createSession: Session @field(resolver: "Lab19\Cart\GraphQL\Mutations\CreateSession@create")
+    setSession(input: SetSessionInput!): SetSessionPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\SetSession@set")
+    setSessionCurrency(input: SetSessionCurrency!): SetSessionCurrencyPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\SetSession@setCurrency")
+    setSessionGeoLocation: setSessionGeoLocationPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\SetSession@setGeoLocation")
+    createAccount(input: CreateAccountInput! @spread): CreateAccountPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\CreateAccount@create")
+}
+
+type setSessionGeoLocationPayload {
+    geolocation_record: String
+}
+
+type Session {
+    id: ID!
+    token: String!
+    cart_id: ID
+}
+
+input CreateOrderInput {
+    cart: CreateCartRelation
+}
+
+input CreateCartRelation {
+    connect: ID
+    create: CreateCartInput
+    update: UpdateCartInput
+}
+
+input CreateCartInput {
+    item_count: Int
+}
+
+input UpdateCartInput {
+    id: ID
+    item_count: Int
+}
+
+#import user.graphql
+#import products.graphql
+#import orders.graphql
+#import tags.graphql ` 

--- a/shared/js/schema/tags.graphql.js
+++ b/shared/js/schema/tags.graphql.js
@@ -1,0 +1,30 @@
+export default ` extend type Query {
+    tags: [Tag!]! @all(model: "Lab19\Cart\Models\Tag")
+    tag(id: Int! @eq): Tag @find(model: "Lab19\Cart\Models\Tag")
+}
+
+extend type Mutation {
+    createTag(input: CreateTagInput!): Tag
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Tag@create")
+        @can(ability: "create", model: "Lab19\Cart\Models\Tag", policy: "Lab19\Cart\Policies\TagPolicy")
+    updateTag(id: ID!, input: UpdateTagInput!): Tag
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Tag@update")
+        @can(ability: "update", model: "Lab19\Cart\Models\Tag", policy: "Lab19\Cart\Policies\TagPolicy")
+    deleteTag(id: ID!): DeleteResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Tag@delete")
+        @can(ability: "delete", model: "Lab19\Cart\Models\Tag", policy: "Lab19\Cart\Policies\TagPolicy")
+}
+
+type Tag {
+    id: ID!
+    name: String!
+    products: [Product!]! @hasMany(type: "paginator")
+}
+
+input CreateTagInput {
+    name: String!
+}
+
+input UpdateTagInput {
+    name: String!
+} ` 

--- a/shared/js/schema/user.graphql.js
+++ b/shared/js/schema/user.graphql.js
@@ -1,0 +1,159 @@
+export default ` input CreateAccountInput {
+    name: String!
+    email: String @rules(apply: ["required", "email", "unique:cart_users,email"])
+    password: String!
+    token: String
+}
+
+type CreateAccountPayload {
+    token: String
+    user: User
+}
+
+input SetSessionInput {
+    products: [CartProductInput!]
+}
+
+input SetSessionCurrency {
+    currency: String!
+}
+
+input CartProductInput {
+    id: ID!
+    quantity: Int!
+}
+
+type SetSessionPayload {
+    cart_uuid: String
+    products: [CartProduct]
+}
+
+type SetSessionCurrencyPayload {
+    currency: String
+    rate: String
+}
+
+type CartProduct {
+    id: ID!
+    quantity: Int!
+}
+
+extend type Mutation {
+    logIn(input: LoginInput! @spread): LogInPayload @field(resolver: "Lab19\Cart\GraphQL\Mutations\Account@logIn")
+
+    logOut: LogOutPayload @field(resolver: "Lab19\Cart\GraphQL\Mutations\Account@logOut")
+
+    addToCart(input: AddToCartInput!): CartPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Cart@addToCart")
+        @gate(ability: "add-to-cart", sessionOnly: true)
+
+    removeFromCart(input: RemoveFromCartInput!): CartPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Cart@removeFromCart")
+        @gate(ability: "remove-from-cart", sessionOnly: true)
+
+    updateCartQuantity(input: UpdateCartQuantityInput!): CartPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\Cart@updateCartQuantity")
+        @gate(ability: "add-to-cart", sessionOnly: true)
+
+    createUser(input: CreateUserInput!): CreateUserPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@create")
+        @can(ability: "create", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    updateUser(id: ID!, input: UpdateUserInput!): CreateUserPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@update")
+        @can(ability: "update", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    deleteUser(id: ID!): DeleteResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@delete")
+        @can(ability: "delete", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    elevateUser(id: ID!): CreateUserPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@elevate")
+        @can(ability: "update", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    demoteUser(id: ID!): CreateUserPayload
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@demote")
+        @can(ability: "update", model: "Lab19\Cart\Models\User", policy: "Lab19\Cart\Policies\UserPolicy")
+
+    resetUserPasswordLink(email: String!): SendResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@resetPasswordLink")
+
+    resetPassword(input: UpdatePasswordPayload): UpdatePasswordResult
+        @field(resolver: "Lab19\Cart\GraphQL\Mutations\User@resetPassword")
+}
+
+input UpdatePasswordPayload {
+    email: String!
+    token: String!
+    password: String!
+    password_confirmation: String!
+}
+
+input LoginInput {
+    email: String!
+    password: String!
+}
+
+type LogInPayload {
+    user: User
+    token: String
+}
+
+type LogOutPayload {
+    success: Boolean!
+}
+
+input AddToCartInput {
+    items: [AddToCartItemInput!]
+}
+
+input AddToCartItemInput {
+    product_id: ID!
+    quantity: Int!
+}
+
+type CartPayload {
+    cart: Cart
+}
+
+input RemoveFromCartInput {
+    product_id: ID!
+    quantity: Int!
+}
+
+input UpdateCartQuantityInput {
+    product_id: ID!
+    quantity: Int!
+}
+
+extend type Query {
+    me: User @field(resolver: "Lab19\Cart\GraphQL\Queries\Account@me")
+    myOrders: [Order!] @field(resolver: "Lab19\Cart\GraphQL\Queries\Account@myOrders")
+}
+
+input CreateUserInput {
+    name: String!
+    email: String! @rules(apply: ["required", "email", "unique:cart_users,email"])
+    password: String!
+}
+
+input UpdateUserInput {
+    name: String
+    email: String @rules(apply: ["email", "unique:cart_users,email"])
+    password: String
+}
+
+type CreateUserPayload {
+    id: ID!
+    name: String!
+    email: String!
+    is_admin: Int
+}
+
+type SendResult {
+    success: Boolean!
+}
+
+type UpdatePasswordResult {
+    success: Boolean!
+} ` 


### PR DESCRIPTION
During unit tests, the formatting provided by lighthouse is not valid for the graphql mock server, so an altered version is required. This script can generate these files. They should be committed to git to mirror the latest applicable version. 